### PR TITLE
resend email-confirmation email feature for registration and email change

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -26,6 +26,7 @@ $routes->post('/user/reset_password', 'UserController::handleResetPassword', ['f
 
 $routes->get('/user/profile', 'UserController::profile', ['filter' => LoggedInFilter::class]);
 $routes->post('/user/profile', 'UserController::handleProfile', ['filter' => LoggedInFilter::class]);
+$routes->post('/user/profile/resend', 'UserController::handleProfileResendConfirmationEmail', ['filter' => LoggedInFilter::class]);
 
 $routes->get('/user/confirm', 'UserController::handleConfirm');
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -19,6 +19,7 @@ $routes->get('/logout', 'AuthenticationController::logout', ['filter' => LoggedI
 
 $routes->get('/register', 'AuthenticationController::register', ['filter' => LoggedOutFilter::class]);
 $routes->post('/register', 'AuthenticationController::handleRegister', ['filter' => LoggedOutFilter::class]);
+$routes->post('/register/resend', 'AuthenticationController::handleRegisterResendConfirmationEmail', ['filter' => LoggedOutFilter::class]);
 
 $routes->get('/user/reset_password', 'UserController::resetPassword', ['filter' => LoggedOutFilter::class]);
 $routes->post('/user/reset_password', 'UserController::handleResetPassword', ['filter' => LoggedOutFilter::class]);

--- a/app/Controllers/AuthenticationController.php
+++ b/app/Controllers/AuthenticationController.php
@@ -11,6 +11,7 @@ use function App\Helpers\createGroupMembershipRequest;
 use function App\Helpers\createUser;
 use function App\Helpers\generateUsername;
 use function App\Helpers\getUserByEmail;
+use function App\Helpers\getUserById;
 use function App\Helpers\getUserByUsername;
 use function App\Helpers\hashSSHA;
 use function App\Helpers\saveUser;
@@ -125,7 +126,19 @@ class AuthenticationController extends BaseController
             return redirect('register')->withInput()->with('error', 'Fehler beim Speichern: ' . $e->getMessage());
         }
 
-        return redirect('register')->with('success', 1);
+        return redirect('register')->with('success', 1)->with('userId', $id)->with('email', $email);
+    }
+
+    public function handleRegisterResendConfirmationEmail(): string|RedirectResponse
+    {
+        $userId = $this->request->getPost('userId');
+        $user = getUserById($userId);
+        try {
+            queueMail($userId, 'E-Mail bestätigen', view('mail/ConfirmEmail', ['user' => $user]));
+        } catch (Exception $e) {
+            return redirect('register')->with('success', 1)->with('resend', 'failure')->with('userId', $userId)->with('email', $user->getEmail());
+        }
+        return redirect('register')->with('success', 1)->with('resend', 'success')->with('userId', $userId)->with('email', $user->getEmail());
     }
 
     public function logout(): RedirectResponse

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -8,6 +8,7 @@ use Exception;
 use Ramsey\Uuid\Uuid;
 use function App\Helpers\getCurrentUser;
 use function App\Helpers\getUserByEmail;
+use function App\Helpers\getUserById;
 use function App\Helpers\getUserByToken;
 use function App\Helpers\getUserByUsernameAndEmail;
 use function App\Helpers\getUserByUsernameAndPassword;
@@ -65,6 +66,18 @@ class UserController extends BaseController
         }
 
         return redirect('user/profile')->with('success', 1);
+    }
+
+    public function handleProfileResendConfirmationEmail(): RedirectResponse
+    {
+        $userId = $this->request->getPost('userId');
+        $user = getUserById($userId);
+        try {
+            queueMail($userId, 'E-Mail bestätigen', view('mail/ConfirmEmail', ['user' => $user]));
+        } catch (Exception $e) {
+            return redirect('user/profile')->with('error', 'Fehler beim erneuten Versenden der E-Mail: ' . $e->getMessage());
+        }
+        return redirect('user/profile')->with('success', 1)->with('resendSuccess', 1);
     }
 
     public function resetPassword(): string

--- a/app/Views/auth/RegisterView.php
+++ b/app/Views/auth/RegisterView.php
@@ -7,7 +7,7 @@ use function App\Helpers\getSchoolsByRegionId;
 ?>
     <main>
     <div class="container login">
-<?= form_open('register') ?>
+
     <div class="card register">
         <div class="card-header header-plain">
             <img class="mb-2 navbar-brand-logo" src="<?= base_url('/') ?>/assets/img/banner_small.png"
@@ -15,87 +15,111 @@ use function App\Helpers\getSchoolsByRegionId;
             <h1 class="h2">Registrieren</h1>
         </div>
         <?php if (session('success')): ?>
-            <div class="card-body">
-                <div class="alert alert-success">
-                    <b>Registrierung erfolgreich!</b> Dein Account wurde erfolgreich angelegt. Wir haben dir nun
-                    eine E-Mail mit einem Bestätigungslink gesendet. Bitte klicke auf diesen Link, um
-                    mit der Registrierung fortzufahren!
+            <?= form_open('register/resend', '', ['userId' => session('userId')]) ?>
+                <div class="card-body">
+
+                    <?php if (session('resend')): ?>
+
+                        <?php if (session('resend') === 'success'): ?>
+                            <div class="alert alert-success">
+                                <b>Erneuter Versand erfolgreich!</b> Wir haben dir eine weitere E-Mail mit einem
+                                Bestätigungslink an <?= session('email') ?> gesendet. Bitte klicke auf diesen Link,
+                                um mit der Registrierung fortzufahren!
+                            </div>
+                        <?php else: ?>
+                            <div class="alert alert-danger">
+                                <b>Erneuter Versand fehlgeschlagen!</b> Wir haben versucht dir eine weitere E-Mail mit
+                                Bestätigungslink an <?= session('email') ?> zu senden, aber etwas ist
+                                schiefgegangen. Wende dich bitte an technik@waldorfconnect.de!
+                            </div>
+                        <?php endif; ?>
+
+                    <?php else: ?>
+                        <div class="alert alert-success">
+                            <b>Registrierung erfolgreich!</b> Dein Account wurde angelegt. Wir haben dir nun eine E-Mail mit
+                            einem Bestätigungslink an <?= session('email') ?> gesendet. Bitte klicke auf diesen Link, um mit
+                            der Registrierung fortzufahren!
+                        </div>
+                    <?php endif; ?>
+
+                    <button class="btn btn-link text-dark" type="submit">Nach ein paar Minuten noch keine E-Mail erhalten? Erneut anfordern!</button>
                 </div>
-            </div>
+            <?= form_close(); ?>
         <?php else: ?>
-            <div class="card-body">
-                <?php if ($error = session('error')): ?>
-                    <div class="alert alert-danger">
-                        <?= $error ?>
+            <?= form_open('register') ?>
+                <div class="card-body">
+                    <?php if ($error = session('error')): ?>
+                        <div class="alert alert-danger">
+                            <?= $error ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <h3>Persönliche Angaben</h3>
+
+                    <div class="mb-3">
+                        <label for="inputName" class="sr-only">Vorname(n)</label>
+                        <input class="form-control" id="inputName" name="name" autocomplete="name"
+                               placeholder="Vor- und Nachname" value="<?= old('name') ?>" required>
                     </div>
-                <?php endif; ?>
 
-                <h3>Persönliche Angaben</h3>
+                    <div class="mb-3">
+                        <label for="inputEmail" class="sr-only">E-Mail</label>
+                        <input type="email" class="form-control" id="inputEmail" name="email" autocomplete="email"
+                               placeholder="E-Mail" value="<?= old('email') ?>" required>
+                    </div>
 
-                <div class="mb-3">
-                    <label for="inputName" class="sr-only">Vorname(n)</label>
-                    <input class="form-control" id="inputName" name="name" autocomplete="name"
-                           placeholder="Vor- und Nachname" value="<?= old('name') ?>" required>
+                    <div class="mb-3">
+                        <label for="inputPassword" class="sr-only">Passwort</label>
+                        <input type="password" class="form-control" id="inputPassword" name="password"
+                               autocomplete="new-password" placeholder="Passwort" required>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="inputConfirmedPassword" class="sr-only">Passwort wiederholen</label>
+                        <input type="password" class="form-control" id="inputConfirmedPassword"
+                               name="confirmedPassword"
+                               autocomplete="new-password" placeholder="Passwort wiederholen" required>
+                    </div>
+
+                    <h3 class="mt-5">Organisationsangaben</h3>
+
+                    <div class="mb-3">
+                        <label for="inputSchool" class="form-label">Schule</label>
+                        <select class="form-select" id="inputSchool" name="school" required>
+                            <?php foreach (getRegions() as $region): ?>
+                                <optgroup label="<?= $region->getName() ?>">
+                                    <?php foreach (getSchoolsByRegionId($region->getId()) as $school): ?>
+                                        <option <?= $school->getId() == old('school') ? 'selected' : '' ?>
+                                                value="<?= $school->getId() ?>"><?= $school->name ?></option>
+                                    <?php endforeach; ?>
+                                </optgroup>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="inputGroups" class="form-label">Organisationen/Gruppen</label>
+                        <select class="form-select" id="inputGroups" name="groups[]" aria-describedby="groupsHelp" multiple
+                                required>
+                            <?php foreach (getRegions() as $region): ?>
+                                <optgroup label="<?= $region->getName() ?>">
+                                    <?php foreach (getGroupsByRegionId($region->getId()) as $group): ?>
+                                        <option <?= !is_null(old('groups')) && in_array($group->getId(), old('groups')) ? 'selected' : '' ?>
+                                                value="<?= $group->getId() ?>"><?= $group->name ?></option>
+                                    <?php endforeach; ?>
+                                </optgroup>
+                            <?php endforeach; ?>
+                        </select>
+                        <small id="groupsHelp" class="form-text text-muted">Zur Auswahl mehrerer Gruppen auf
+                            Desktop-Geräten die STRG-Taste gedrückt halten.</small>
+                    </div>
+
                 </div>
-
-                <div class="mb-3">
-                    <label for="inputEmail" class="sr-only">E-Mail</label>
-                    <input type="email" class="form-control" id="inputEmail" name="email" autocomplete="email"
-                           placeholder="E-Mail" value="<?= old('email') ?>" required>
+                <div class="card-footer footer-plain">
+                    <button class="btn btn-primary btn-block" type="submit">Registrieren</button>
+                    <a class="btn btn-link text-dark"
+                       href="<?= base_url('/login') ?>">Bereits registriert? Jetzt anmelden!</a>
                 </div>
-
-                <div class="mb-3">
-                    <label for="inputPassword" class="sr-only">Passwort</label>
-                    <input type="password" class="form-control" id="inputPassword" name="password"
-                           autocomplete="new-password" placeholder="Passwort" required>
-                </div>
-
-                <div class="mb-3">
-                    <label for="inputConfirmedPassword" class="sr-only">Passwort wiederholen</label>
-                    <input type="password" class="form-control" id="inputConfirmedPassword"
-                           name="confirmedPassword"
-                           autocomplete="new-password" placeholder="Passwort wiederholen" required>
-                </div>
-
-                <h3 class="mt-5">Organisationsangaben</h3>
-
-                <div class="mb-3">
-                    <label for="inputSchool" class="form-label">Schule</label>
-                    <select class="form-select" id="inputSchool" name="school" required>
-                        <?php foreach (getRegions() as $region): ?>
-                            <optgroup label="<?= $region->getName() ?>">
-                                <?php foreach (getSchoolsByRegionId($region->getId()) as $school): ?>
-                                    <option <?= $school->getId() == old('school') ? 'selected' : '' ?>
-                                            value="<?= $school->getId() ?>"><?= $school->name ?></option>
-                                <?php endforeach; ?>
-                            </optgroup>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-
-                <div class="mb-3">
-                    <label for="inputGroups" class="form-label">Organisationen/Gruppen</label>
-                    <select class="form-select" id="inputGroups" name="groups[]" aria-describedby="groupsHelp" multiple
-                            required>
-                        <?php foreach (getRegions() as $region): ?>
-                            <optgroup label="<?= $region->getName() ?>">
-                                <?php foreach (getGroupsByRegionId($region->getId()) as $group): ?>
-                                    <option <?= !is_null(old('groups')) && in_array($group->getId(), old('groups')) ? 'selected' : '' ?>
-                                            value="<?= $group->getId() ?>"><?= $group->name ?></option>
-                                <?php endforeach; ?>
-                            </optgroup>
-                        <?php endforeach; ?>
-                    </select>
-                    <small id="groupsHelp" class="form-text text-muted">Zur Auswahl mehrerer Gruppen auf
-                        Desktop-Geräten die STRG-Taste gedrückt halten.</small>
-                </div>
-
-            </div>
-            <div class="card-footer footer-plain">
-                <button class="btn btn-primary btn-block" type="submit">Registrieren</button>
-                <a class="btn btn-link text-dark"
-                   href="<?= base_url('/login') ?>">Bereits registriert? Jetzt anmelden!</a>
-            </div>
+            <?= form_close(); ?>
         <?php endif; ?>
     </div>
-<?= form_close(); ?>

--- a/app/Views/user/EditProfileView.php
+++ b/app/Views/user/EditProfileView.php
@@ -16,7 +16,7 @@ $self = getCurrentUser();
     </div>
 <?php endif; ?>
 
-<?php if (session('success')): ?>
+<?php if (session('success') && !session('resendSuccess')): ?>
     <div class="alert alert-success mb-3">
         Profil gespeichert.
     </div>
@@ -45,6 +45,13 @@ $self = getCurrentUser();
                    placeholder="E-Mail" value="<?= $self->getEmail() ?>" aria-describedby="emailHelp" required>
             <?php if ($self->getStatus() == UserStatus::PENDING_EMAIL): ?>
                 <span id="emailHelp" class="badge bg-warning">Warte auf Bestätigung</span>
+                <?php if (session('resendSuccess')): ?>
+                <span id="resentBadge" class="badge bg-success">Erneut versandt</span>
+                <?php endif; ?>
+                <button type="button" class="btn btn-link btn-sm text-dark"
+                        onclick="document.getElementById('resendEmailButton').click();">
+                        Nach ein paar Minuten noch keine E-Mail erhalten? Erneut anfordern!
+                </button>
             <?php else: ?>
                 <span id="emailHelp" class="badge bg-success">E-Mail bestätigt</span>
             <?php endif; ?>
@@ -72,4 +79,8 @@ $self = getCurrentUser();
     </div>
 
     <button class="btn btn-primary btn-block" type="submit">Speichern</button>
+<?= form_close() ?>
+
+<?= form_open('user/profile/resend', ['class' => 'd-none', 'id' => 'resendEmailForm'], ['userId' => $self->getId()]) ?>
+    <button id="resendEmailButton" type="submit">E-Mail erneut versenden</button>
 <?= form_close() ?>


### PR DESCRIPTION
add the feature, that a user can himself request another confirmation email (in case it didn't make its way) in two places:

- when someone registers and awaits the email that shall confirm that he owns his provided email address
- when someone changes his email via "edit profile" and shall confirm that he owns the new email address he provided