### PR TITLE
Feature role edit

### DIFF
--- a/app/Controllers/AdminController.php
+++ b/app/Controllers/AdminController.php
@@ -126,6 +126,7 @@ class AdminController extends BaseController
         $email = $this->request->getPost('email');
         $schoolId = $this->request->getPost('school');
         $role = $this->request->getPost('role');
+        $status = $this->request->getPost('status');
         $password = $this->request->getPost('password');
         $confirmedPassword = $this->request->getPost('confirmedPassword');
 
@@ -143,6 +144,7 @@ class AdminController extends BaseController
 
         if ($self->getRole() == UserRole::GLOBAL_ADMIN) {
             $user->setRole(UserRole::from($role));
+            $user->setStatus(UserStatus::from($status));
         }
 
         // Check if user wants to change password

--- a/app/Controllers/AdminController.php
+++ b/app/Controllers/AdminController.php
@@ -50,9 +50,17 @@ class AdminController extends BaseController
         $userId = $this->request->getPost('id');
         $user = getUserById($userId);
 
+        $status = $user->getStatus();
+
         // User awaiting acceptance
-        if ($user->getStatus() != UserStatus::PENDING_ACCEPT) {
+        if ($status == UserStatus::PENDING_ACCEPT || $status == UserStatus::PENDING_REGISTER) {
+
+        } elseif ($status == UserStatus::OK) {
             return redirect('admin/users')->with('error', 'Dieser Nutzer wurde bereits akzeptiert.');
+        } elseif ($status == UserStatus::DENIED) {
+            return redirect('admin/users')->with('error', 'Dieser Nutzer wurde bereits abgelehnt.');
+        } else {
+            redirect('admin/users')->with('error', "Dieser Nutzer hat den Status $status und kann nicht akzeptiert werden.");
         }
 
         $user->setStatus(UserStatus::OK);
@@ -72,9 +80,19 @@ class AdminController extends BaseController
         $user = getUserById($userId);
 
         // User awaiting acceptance
-        if ($user->getStatus() != UserStatus::PENDING_ACCEPT) {
+        $status = $user->getStatus();
+
+        // User awaiting acceptance
+        if ($status == UserStatus::PENDING_ACCEPT || $status == UserStatus::PENDING_REGISTER) {
+
+        } elseif ($status == UserStatus::OK) {
+            return redirect('admin/users')->with('error', 'Dieser Nutzer wurde bereits akzeptiert.');
+        } elseif ($status == UserStatus::DENIED) {
             return redirect('admin/users')->with('error', 'Dieser Nutzer wurde bereits abgelehnt.');
+        } else {
+            redirect('admin/users')->with('error', "Dieser Nutzer hat den Status $status und kann nicht abgelehnt werden.");
         }
+
 
         $user->setStatus(UserStatus::DENIED);
         try {

--- a/app/Views/admin/user/UserEditView.php
+++ b/app/Views/admin/user/UserEditView.php
@@ -97,6 +97,20 @@ $currentUser = getCurrentUser();
     </div>
 
     <div class="form-group row mb-3">
+        <label for="inputStatus" class="col-form-label col-md-4 col-lg-3">Status</label>
+        <div class="col-md-8 col-lg-9">
+            <select class="form-select" id="inputStatus" name="status"
+                    required <?= $currentUser->getRole() != UserRole::GLOBAL_ADMIN ? "disabled" : "" ?>>
+                <?php foreach (UserStatus::cases() as $status): ?>
+                    <option <?= $status == $user->getStatus() ? 'selected' : '' ?>
+                            value="<?= $status->value ?>"><?= $status->displayName() ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+    </div>
+
+
+    <div class="form-group row mb-3">
         <label for="inputPassword" class="col-form-label col-md-4 col-lg-3">Passwort</label>
         <div class="col-md-8 col-lg-9">
             <input type="password" class="form-control" id="inputPassword" name="password"

--- a/app/Views/admin/user/UsersView.php
+++ b/app/Views/admin/user/UsersView.php
@@ -68,7 +68,7 @@ use function App\Helpers\getUsers;
                 <td><?= $user->getRole()->badge() ?></td>
                 <td><?= $user->getStatus()->badge() ?></td>
                 <td>
-                    <?php if ($user->getStatus() == UserStatus::PENDING_ACCEPT): ?>
+                    <?php if ($user->getStatus() == UserStatus::PENDING_ACCEPT || $user->getStatus() == UserStatus::PENDING_REGISTER): ?>
                         <?= form_open('admin/user/accept') ?>
                         <?= form_hidden('id', $user->getId()) ?>
                         <button type="submit" class="btn btn-success">


### PR DESCRIPTION
This allows admins to change the roles of members in the user edit view.
this can be useful to easily promote users (idk how to do it right now)
Also added ability to accept users before they confirmed their email.
this is useful when getting new users at live events where the user might register but not have their email ready.